### PR TITLE
Fix duplicate copy imports

### DIFF
--- a/midigen.py
+++ b/midigen.py
@@ -50,7 +50,6 @@ class InstrumentManager:
         return inst
 
     def duplicate_instrument(self, instrument_id):
-        import copy
         inst = self.get_instrument_by_id(instrument_id)
         if inst:
             new_inst = copy.deepcopy(inst)


### PR DESCRIPTION
## Summary
- deduplicate copy import

## Testing
- `pytest -q`
- `python -m py_compile midigen.py`


------
https://chatgpt.com/codex/tasks/task_e_684c7a557c308328ae580182658c8949