### PR TITLE
Add running tests docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ streamlit run midigen.py
 
 The application will open in your browser at `http://localhost:8501/`.
 
+## Running Tests
+
+Install the dependencies and execute the test suite with:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+If you encounter import errors or missing packages, rerun the install command above to ensure all requirements are present.
+
 ## Features
 
 * Import and export MIDI, CKC and CKI files


### PR DESCRIPTION
## Summary
- document how to run tests using `pip install -r requirements.txt` and `pytest`
- note how to reinstall packages if tests fail due to missing dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c97b4e0c883288f51e73166ee38e8