### PR TITLE
Add basic unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ The application will open in your browser at `http://localhost:8501/`.
 * Validation tools to ensure notes fit a musical scale
 * Audio preview using a SoundFont file
 
+## Running Tests
+
+Run the unit tests with:
+
+```bash
+pytest
+```
+
 ## License
 
 This project is provided as-is for demonstration purposes.

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,54 @@
+import importlib
+import json
+import sys
+import types
+import numpy as np
+
+class DummyStreamlit(types.ModuleType):
+    def __getattr__(self, name):
+        def no_op(*args, **kwargs):
+            return None
+        return no_op
+
+sys.modules.setdefault('streamlit', DummyStreamlit('streamlit'))
+sys.modules.setdefault('streamlit_drawable_canvas', DummyStreamlit('streamlit_drawable_canvas'))
+
+midigen = importlib.import_module('midigen')
+
+
+def make_notes():
+    return [np.array([[0, 60, 100, 120, 0], [120, 62, 100, 120, 0]])]
+
+
+def test_export_ckc(tmp_path):
+    path = tmp_path / 'test.ckc'
+    midigen.export_ckc(make_notes(), str(path))
+    assert path.exists()
+    with open(path, 'rb') as f:
+        assert f.read(4) == b'CKC0'
+
+
+def test_export_cki(tmp_path):
+    path = tmp_path / 'test.cki'
+    midigen.export_cki(make_notes(), str(path))
+    assert path.exists()
+    with open(path) as f:
+        assert f.readline().startswith('CKI')
+
+
+def test_export_p3pattern_json(tmp_path):
+    path = tmp_path / 'pattern.json'
+    midigen.export_p3pattern_json(make_notes(), str(path))
+    assert path.exists()
+    with open(path) as f:
+        data = json.load(f)
+    assert 'p3_pattern' in data
+
+
+def test_export_auxrows(tmp_path):
+    path = tmp_path / 'aux.json'
+    midigen.export_auxrows(make_notes(), str(path))
+    assert path.exists()
+    with open(path) as f:
+        data = json.load(f)
+    assert 'aux_rows' in data

--- a/tests/test_midi.py
+++ b/tests/test_midi.py
@@ -1,0 +1,31 @@
+import importlib
+import io
+import sys
+import tempfile
+import types
+
+import numpy as np
+import mido
+
+class DummyStreamlit(types.ModuleType):
+    def __getattr__(self, name):
+        def no_op(*args, **kwargs):
+            return None
+        return no_op
+
+sys.modules.setdefault('streamlit', DummyStreamlit('streamlit'))
+sys.modules.setdefault('streamlit_drawable_canvas', DummyStreamlit('streamlit_drawable_canvas'))
+
+midigen = importlib.import_module('midigen')
+
+def test_midi_to_poly_dataset_simple():
+    mid = mido.MidiFile()
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.Message('note_on', note=60, velocity=100, time=0))
+    track.append(mido.Message('note_off', note=60, velocity=100, time=480))
+    with tempfile.NamedTemporaryFile(suffix='.mid') as tmp:
+        mid.save(tmp.name)
+        data = midigen.midi_to_poly_dataset(tmp.name)
+    assert data.shape[1] == 5
+    assert data[0][1] == 60

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+import tempfile
+import types
+import numpy as np
+
+class DummyStreamlit(types.ModuleType):
+    def __getattr__(self, name):
+        def no_op(*args, **kwargs):
+            return None
+        return no_op
+
+sys.modules.setdefault('streamlit', DummyStreamlit('streamlit'))
+sys.modules.setdefault('streamlit_drawable_canvas', DummyStreamlit('streamlit_drawable_canvas'))
+
+midigen = importlib.import_module('midigen')
+
+
+def test_train_poly_model(tmp_path):
+    notes = np.array([[0, 60, 64, 120, 0], [120, 62, 64, 120, 0]], dtype=float)
+    model_file = tmp_path / 'model.pt'
+    params = {'lr': 0.001, 'epochs': 1, 'model_path': str(model_file)}
+    model = midigen.train_poly_model(notes, params)
+    assert model is not None
+    assert model_file.exists()


### PR DESCRIPTION
## Summary
- add a pytest suite covering MIDI parsing, exports and training routine
- document how to run the test suite

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c7a513ce88328ab85187ab50b021c